### PR TITLE
Fixed server.xml quote issue and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ chmod -R 750 ./dataXform
 </connectionFactory>
 ```
 
-**NOTE:** Change the <server-name> to the actual name of the z/OS Connect instance you created. A sample **server.xml** is included in the package. If you want to use the sample server.xml file then upload it to z/OS in binary mode to keep the contents in ASCII format.
+**NOTE:** Change the server-name to the actual name of the z/OS Connect instance you created. A sample server.xml is included in the package. If you want to use the sample server.xml file then upload it to z/OS in binary mode to keep the contents in ASCII format.
 
 At this point you have service definitions to match the COBOL service sample provided but do not yet have an API created and deployed.
 

--- a/server.xml
+++ b/server.xml
@@ -26,7 +26,7 @@
     <zosconnect_zosConnectManager requireSecure="false" requireAuth="false"/>
 
     <zosconnect_zosConnectAPIs location="">
-        <zosConnectAPI name=“CobolService”/>
+        <zosConnectAPI name='CobolService'/>
     </zosconnect_zosConnectAPIs>
 
     <zosconnect_zosConnectService dataXformRef="xformJSON2Byte" 
@@ -52,9 +52,9 @@
             registerName="COBOLZCON" 
             serviceName="CobolService"/>
 
-    <zosLocalAdapters wolaGroup=“GRPNAME1”
-            wolaName2=“GRPNAME2” 
-            wolaName3=“GRPNAME3”/>
+    <zosLocalAdapters wolaGroup="GRPNAME1"
+            wolaName2="GRPNAME2" 
+            wolaName3="GRPNAME3"/>
 
     <connectionFactory id="wolaCF" jndiName="eis/ola">
         <properties.ola/>


### PR DESCRIPTION
The double quote characters on several lines in server.xml were causing issues are server startup. This version fixes the double quote characters to be read at startup. Also the readme.md file was updated to allow it to display properly in the git browser view.
